### PR TITLE
Exclude Three.js from THREEAR libary

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,9 @@ module.exports = {
     filename: 'THREEAR.js',
     path: __dirname + '/dist'
   },
+  externals: {
+		three: 'THREE',
+	},
   plugins: [
     new PrettierPlugin()
   ]


### PR DESCRIPTION
See https://github.com/JamesMilnerUK/THREEAR/issues/67

Reduces the lib size quite a bit from 2MB to 1.42MB